### PR TITLE
chore: rename to s3-auth-proxy

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -8,7 +8,7 @@ plugins:
     - preset: conventionalcommits
   - - "@semantic-release/changelog"
     - changelogFile: CHANGELOG.md
-      changelogTitle: "# ØKP4 minio auth plugin"
+      changelogTitle: "# ØKP4 S3 auth proxy"
   - - "@google/semantic-release-replace-plugin"
     - replacements:
         - files: [version]
@@ -25,18 +25,18 @@ plugins:
         make build-go-all
   - - "@semantic-release/github"
     - assets:
-        - name: minio-auth-plugin_darwin_amd64
+        - name: s3-auth-proxy_darwin_amd64
           label: Binary - Darwin amd64
-          path: "./target/dist/darwin/amd64/minio-auth-plugin"
-        - name: minio-auth-plugin_darwin_arm64
+          path: "./target/dist/darwin/amd64/s3-auth-proxy"
+        - name: s3-auth-proxy_darwin_arm64
           label: Binary - Darwin arm64
-          path: "./target/dist/darwin/arm64/minio-auth-plugin"
-        - name: minio-auth-plugin_linux_amd64
+          path: "./target/dist/darwin/arm64/s3-auth-proxy"
+        - name: s3-auth-proxy_linux_amd64
           label: Binary - Linux amd64
-          path: "./target/dist/linux/amd64/minio-auth-plugin"
-        - name: minio-auth-plugin_windows_amd64.exe
+          path: "./target/dist/linux/amd64/s3-auth-proxy"
+        - name: s3-auth-proxy_windows_amd64.exe
           label: Binary - Windows amd64
-          path: "./target/dist/windows/amd64/minio-auth-plugin.exe"
+          path: "./target/dist/windows/amd64/s3-auth-proxy.exe"
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,8 +10,8 @@ RUN make build CGO_ENABLED=0
 #--- Image stage
 FROM alpine:3.19.1
 
-COPY --from=go-builder /src/target/dist/minio-auth-plugin /usr/bin/minio-auth-plugin
+COPY --from=go-builder /src/target/dist/s3-auth-proxy /usr/bin/s3-auth-proxy
 
 WORKDIR /opt
 
-ENTRYPOINT ["/usr/bin/minio-auth-plugin"]
+ENTRYPOINT ["/usr/bin/s3-auth-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ℹ Freely based on: https://gist.github.com/thomaspoignant/5b72d579bd5f311904d973652180c705
 
 # Constants
-BINARY_NAME             = minio-auth-plugin
+BINARY_NAME             = s3-auth-proxy
 TARGET_FOLDER           = target
 DIST_FOLDER             = $(TARGET_FOLDER)/dist
 DOCKER_IMAGE_GOLANG_CI  = golangci/golangci-lint:v1.55
@@ -17,9 +17,9 @@ COLOR_RESET  = $(shell tput -Txterm sgr0)
 VERSION  := $(shell cat version)
 COMMIT   := $(shell git log -1 --format='%H')
 LD_FLAGS  = \
-	-X okp4/minio-auth-plugin/internal/version.Name=$(BINARY_NAME) \
-	-X okp4/minio-auth-plugin/internal/version.Version=$(VERSION)  \
-	-X okp4/minio-auth-plugin/internal/version.Commit=$(COMMIT)
+	-X okp4/s3-auth-proxy/internal/version.Name=$(BINARY_NAME) \
+	-X okp4/s3-auth-proxy/internal/version.Version=$(VERSION)  \
+	-X okp4/s3-auth-proxy/internal/version.Commit=$(COMMIT)
 BUILD_FLAGS := -ldflags '$(LD_FLAGS)'
 
 # Commands

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Minio auth plugin
+# S3 auth proxy
 
-> Minio authentication connector to the OKP4 chain.
+> S3 proxy ensuring authentication and authorization layer based on OKP4.
 
-[![version](https://img.shields.io/github/v/release/okp4/minio-auth-plugin?style=for-the-badge&logo=github)](https://github.com/okp4/minio-auth-plugin/releases)
-[![lint](https://img.shields.io/github/actions/workflow/status/okp4/minio-auth-plugin/lint.yml?branch=main&label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/minio-auth-plugin/actions/workflows/lint.yml)
-[![build](https://img.shields.io/github/actions/workflow/status/okp4/minio-auth-plugin/build.yml?branch=main&label=build&style=for-the-badge&logo=github)](https://github.com/okp4/minio-auth-plugin/actions/workflows/build.yml)
-[![test](https://img.shields.io/github/actions/workflow/status/okp4/minio-auth-plugin/test.yml?branch=main&label=test&style=for-the-badge&logo=github)](https://github.com/okp4/minio-auth-plugin/actions/workflows/test.yml)
-[![codecov](https://img.shields.io/codecov/c/github/okp4/minio-auth-plugin?style=for-the-badge&token=6NL9ICGZQS&logo=codecov)](https://codecov.io/gh/okp4/minio-auth-plugin)
+[![version](https://img.shields.io/github/v/release/okp4/s3-auth-proxy?style=for-the-badge&logo=github)](https://github.com/okp4/s3-auth-proxy/releases)
+[![lint](https://img.shields.io/github/actions/workflow/status/okp4/s3-auth-proxy/lint.yml?branch=main&label=lint&style=for-the-badge&logo=github)](https://github.com/okp4/s3-auth-proxy/actions/workflows/lint.yml)
+[![build](https://img.shields.io/github/actions/workflow/status/okp4/s3-auth-proxy/build.yml?branch=main&label=build&style=for-the-badge&logo=github)](https://github.com/okp4/s3-auth-proxy/actions/workflows/build.yml)
+[![test](https://img.shields.io/github/actions/workflow/status/okp4/s3-auth-proxy/test.yml?branch=main&label=test&style=for-the-badge&logo=github)](https://github.com/okp4/s3-auth-proxy/actions/workflows/test.yml)
+[![codecov](https://img.shields.io/codecov/c/github/okp4/s3-auth-proxy?style=for-the-badge&token=6NL9ICGZQS&logo=codecov)](https://codecov.io/gh/okp4/s3-auth-proxy)
 [![conventional commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg?style=for-the-badge&logo=conventionalcommits)](https://conventionalcommits.org)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=for-the-badge)](https://github.com/semantic-release/semantic-release)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg?style=for-the-badge)](https://github.com/okp4/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -8,9 +8,9 @@ import (
 
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
-	Use:   "minio-auth-plugin",
-	Short: "Minio authentication connector to the OKP4 chain.",
-	Long:  "Minio authentication connector to the OKP4 chain.",
+	Use:   "s3-auth-proxy",
+	Short: "S3 connector to the OKP4 chain.",
+	Long:  "S3 connector to the OKP4 chain.",
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"okp4/minio-auth-plugin/internal/version"
+	"okp4/s3-auth-proxy/internal/version"
 	"strings"
 
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module okp4/minio-auth-plugin
+module okp4/s3-auth-proxy
 
 go 1.21
 

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -18,7 +18,7 @@ func TestNewInfo(t *testing.T) {
 func TestInfoString(t *testing.T) {
 	Convey("Given an info object", t, func() {
 		info := new(Info)
-		info.Name = "minio-auth-plugin"
+		info.Name = "s3-auth-proxy"
 		info.Version = "0.0"
 		info.GitCommit = "13245"
 		info.GoVersion = "go fake version 42"
@@ -26,7 +26,7 @@ func TestInfoString(t *testing.T) {
 		Convey("When the object string function is called", func() {
 			result := info.String()
 			Convey("Then the result should be an info string", func() {
-				expected := `minio-auth-plugin: 0.0
+				expected := `s3-auth-proxy: 0.0
 git commit: 13245
 go fake version 42`
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "okp4/minio-auth-plugin/cmd"
+import "okp4/s3-auth-proxy/cmd"
 
 func main() {
 	cmd.Execute()


### PR DESCRIPTION
Rename the repository & project to `s3-auth-proxy` as it won't be specific to Minio and act more as a proxy than a plugin.